### PR TITLE
Allow command line bundling i.e. -c2

### DIFF
--- a/lib/Mojolicious/Command/secret.pm
+++ b/lib/Mojolicious/Command/secret.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'Mojolicious::Command';
 use Mojo::Util 'class_to_path';
 
 use File::Spec;
-use Getopt::Long qw(GetOptionsFromArray :config no_ignore_case no_auto_abbrev);   # Match Mojo's commands
+use Getopt::Long qw(GetOptionsFromArray :config no_ignore_case no_auto_abbrev bundling); # Match Mojo's commands
 
 our $VERSION = '0.03';
 


### PR DESCRIPTION
Hi, 
This change is to allow `Getopt::Long` to process switches that take arguments where there are no space in between, so `-c2` will be processed as if it was `-c 2`.

Cheers, 
