### PR TITLE
Support building the distrubution via Module::Build for systems without make

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,0 +1,54 @@
+use Module::Build;
+use strict;
+use warnings;
+
+my $found;
+my @modz = qw|Crypt::OpenSSL::Random Crypt::URandom|;
+for(@modz) {
+  if(eval "require $_; 1") {
+    $found = 1;
+    last;
+  }
+}
+
+unless($found) {
+  warn<<END;
+
+Neither $modz[0] or $modz[1] are installed. In order to generate a secret
+you must install one of these modules or, when running the command, specify an alternate
+generator via the `-g` option.
+
+See `mojo secret --help` for more info.
+
+END
+}
+
+my $class = Module::Build->subclass
+  (
+   class => 'My::Builder',
+   code => q{
+     sub ACTION_docs {
+       system('perldoc -uT "lib/Mojolicious/Command/secret.pm" > README.pod');
+     }
+   },
+  );
+
+my $build = $class->new (
+  module_name => 'Mojolicious::Command::secret',
+  license     => 'perl',
+  dist_author => 'Skye Shaw <skye.shaw AT gmail.com>',
+  requires    => { 'Mojolicious' => '4.63' },
+  dist_version_from  => 'lib/Mojolicious/Command/secret.pm',
+  (eval { Module::Build->VERSION(0.28) } ?
+     (meta_merge => {
+       resources => {
+         homepage   => 'http://github.com/sshaw/Mojolicious-Command-secret',
+         bugtracker => 'http://github.com/sshaw/Mojolicious-Command-secret/issues',
+         repository => 'http://github.com/sshaw/Mojolicious-Command-secret'
+        }
+      }
+     ) : ()
+    )
+ );
+
+$build->create_build_script;

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,8 @@
+Build.PL
+Changes
+INSTALL.SKIP
+lib/Mojolicious/Command/secret.pm
+Makefile.PL
+MANIFEST			This list of files
+MANIFEST.SKIP
+README.pod

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,23 @@
+# Makemaker
+^Makefile$
+^blib/
+^MakeMaker-\d
+^pm_to_blib$
+^blibdirs
+
+# Module::Build
+^Build\.bat$
+^Build$
+^_build/
+^cover_db
+
+# version control
+^\.git/
+
+# other files
+^MANIFEST.bak$
+\.tmp$
+\.old$
+^MYMETA\.yml$
+^MYMETA\.json$
+^META\.json$


### PR DESCRIPTION
Hello, 

The changes in this branch is help build, test, install, etc. the module on systems that don't have the `make` utility (which is my case). The `Build.PL` was created based on the existing `Makefile.PL` file. 

I added the `MANIFEST` and the `MANIFEST.SKIP` files in case you're interested on having them included in the repository.

Thanks, 
